### PR TITLE
Deprecate repository

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,13 @@
 All of the functionality of Pywcs is now available in Astropy as the astropy.wcs package.
 This repository is deprecated.
 
+Current documentation is at:
+
+http://docs.astropy.org/en/stable/wcs/index.html
+
+The astropy repository is on github at
+
+https://github.com/astropy/astropy
 
 Introduction
 ------------

--- a/README
+++ b/README
@@ -1,3 +1,7 @@
+All of the functionality of Pywcs is now available in Astropy as the astropy.wcs package.
+This repository is deprecated.
+
+
 Introduction
 ------------
 


### PR DESCRIPTION
Here's a suggestion for directing users to astropy.wcs.
